### PR TITLE
When finding dimensions, filters to video streams

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,14 +34,14 @@ const reportError = (message, err, reporter) => {
 
 function notMemoizedGetVideoDimensions(path) {
   return ffmpeg.ffprobeAsync(path).then(metadata => {
-    // just pick the first stream
+    // just pick the first video stream
 
     if (!metadata[0].streams) {
       console.warn(path, 'has no video streams?')
       return null
     }
 
-    const stream = metadata[0].streams[0]
+    const stream = metadata[0].streams.filter(s => s.codec_type === 'video')[0]
 
     return {
       width: stream.width,


### PR DESCRIPTION
I had a video off my phone where the audio stream was the first one, so
ffmpeg was generating NaN dimensions for the video.

This change filters the streams to video-only before picking the first
one for determining dimensions.